### PR TITLE
Fixed sps-i macro usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ VRChat is switching to SPS-I.  Please perform the following to test your shaders
 
 Add this to your appdata:
 ```hlsl
-UNITY_VERTEX_INPUT_INSTANCE_ID;
+UNITY_VERTEX_INPUT_INSTANCE_ID
 ```
 
 Add this to your `v2f` struct:
 ```hlsl
-UNITY_VERTEX_OUTPUT_STEREO;
+UNITY_VERTEX_OUTPUT_STEREO
 ```
 
 Add this to your `vertex` shader:


### PR DESCRIPTION
Semicolons are not needed when using these macros, adding a semicolon results in a compilation error

Other instances of this are correct across the doc, so it was just this one spot